### PR TITLE
fix: rename label to value

### DIFF
--- a/index.js
+++ b/index.js
@@ -533,7 +533,7 @@ function getPixelInEntry(x, y, entry) {
 function getLoopType(entry) {
   const text = entry.details[0];
   switch(text) {
-    default: return `|type=?|label=${text}`;
+    default: return `|type=?|value=${text}`;
     case 'forever!': return ''; // Loop template defaults to "forever"
     case 'backpack':
     case 'hands':


### PR DESCRIPTION
Commands use value as a way to specify text, now loops do as well.

Not really sure why I used label before, glad I'm changing this early enough to not be a problem though.